### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/fylm/fylmlib/compare.py
+++ b/fylm/fylmlib/compare.py
@@ -26,7 +26,7 @@ import re
 import warnings
 warnings.filterwarnings("ignore", message="Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning")
 
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 import fylmlib.formatter as formatter
 import fylmlib.patterns as patterns

--- a/fylm/fylmlib/tmdb.py
+++ b/fylm/fylmlib/tmdb.py
@@ -33,7 +33,7 @@ import warnings
 warnings.filterwarnings("ignore", message="Using slow pure-python SequenceMatcher. Install python-Levenshtein to remove this warning")
 
 import tmdbsimple as tmdb
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 import fylmlib.config as config
 from fylmlib.console import console

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ PlexAPI
 requests>=2.20.0
 pymediainfo>=4.0
 future-fstrings>=1.2.0
-fuzzywuzzy>=0.17.0
+rapidfuzz>=0.2.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.